### PR TITLE
Add scales

### DIFF
--- a/tests/test_tsunami.py
+++ b/tests/test_tsunami.py
@@ -64,6 +64,7 @@ def read_file(test_file_path, recording_data):
     rec2 = tf.create_recording(name="Recording_2", **params)
     rec2.append(data)
     rec2.append(data)
+    rec2.append(data[:100])
 
     psig = tsu.Signal(parent_handle=rec2._signals_handle, name='processed', **params)
     psig.append(data * 2)

--- a/tsunami/tsunami.py
+++ b/tsunami/tsunami.py
@@ -217,12 +217,13 @@ class Signal:
             A tuple containing the signal info and data as a numpy array with shape (nsamples, nchannels).
         """
         if npoints:
+            sorted_scales = sorted(self.scales, key=lambda x: x.scale_factor, reverse=True)
             requested_scale_factor = (end_time - start_time) * self.samplerate / npoints
-            if requested_scale_factor < 1:
+            if requested_scale_factor < sorted_scales[-1].scale_factor:
                 dset = self._handle[self.base_name]
                 scale_factor = 1
             else:
-                for s in sorted(self.scales, key=lambda x: x.scale_factor, reverse=True):  # pragma: no branch
+                for s in sorted_scales:  # pragma: no branch
                     if s.scale_factor < requested_scale_factor:
                         break
                 dset = s._handle

--- a/tsunami/tsunami.py
+++ b/tsunami/tsunami.py
@@ -222,7 +222,7 @@ class Signal:
                 dset = self._handle[self.base_name]
                 scale_factor = 1
             else:
-                for s in sorted(self.scales, key=lambda x: x.scale_factor, reverse=True):
+                for s in sorted(self.scales, key=lambda x: x.scale_factor, reverse=True):  # pragma: no branch
                     if s.scale_factor < requested_scale_factor:
                         break
                 dset = s._handle


### PR DESCRIPTION
Store different scales (decimations) of signal data which are updated automatically when writing data to the recording.

Example structure with a scale-factor of 4 for each subsequent level:
```
(G): recordings
|   (G): Recording_0
|   |   (G): signals
|   |   |   (G): raw
|   |   |   |   (D): signal_data (48000, 1)
|   |   |   |   (D): signal_data_4 (12000, 1)
|   |   |   |   (D): signal_data_16 (3000, 1)
|   |   |   |   (D): signal_data_64 (750, 1)
|   |   |   |   (D): signal_data_256 (187, 1)
|   |   |   |   (D): signal_data_1024 (46, 1)
|   |   |   |   (D): signal_data_4096 (11, 1)
|   |   |   |   (D): signal_data_16384 (2, 1)
|   |   |   |   (D): signal_data_65536 (0, 1)
|   (G): Recording_2
|   |   (G): signals
|   |   |   (G): raw
|   |   |   |   (D): signal_data (96100, 1)
|   |   |   |   (D): signal_data_4 (24025, 1)
|   |   |   |   (D): signal_data_16 (6006, 1)
|   |   |   |   (D): signal_data_64 (1501, 1)
|   |   |   |   (D): signal_data_256 (375, 1)
|   |   |   |   (D): signal_data_1024 (93, 1)
|   |   |   |   (D): signal_data_4096 (23, 1)
|   |   |   |   (D): signal_data_16384 (5, 1)
|   |   |   |   (D): signal_data_65536 (1, 1)
```